### PR TITLE
Updates for newer OTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - name: Check out project

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,8 +5,11 @@ on:
 #     branches: [ master ]
   pull_request:
     branches: [ master ]
-  repository_dispatch:
-    types: manual-trigger
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for running'
+        required: true
 
 jobs:
   build:
@@ -15,6 +18,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Log reason (manual run only)
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "Reason for triggering: ${{ github.event.inputs.reason }}"
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v1

--- a/tests/test_ots_suite.py
+++ b/tests/test_ots_suite.py
@@ -61,4 +61,5 @@ EXPECT_FAIL = {
     'fuzzing/52b6e52e7382c7c7e5ce839cc5df0cd3ae133add.ttf',
     'fuzzing/aca5f8ef7bc0754b0b6fd7a1abd4c69ca7801780.ttf',
     'fuzzing/8240789f6d12d4cfc4b5e8e6f246c3701bcf861f.otf',
+    'fuzzing/3857535d8c0d2bfeab7ee2cd6ba5e39bcb4abd90.ttf',
 }


### PR DESCRIPTION
- update setup to search/replace OTS's `meson.build` rather than previous fragile approach of storing the entire thing
- update GitHub Actions workflows, including addition of Python 3.9 builds for release workflow
