### PR TITLE
Updates for ots 8.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,141 +1,101 @@
-name: Create Release and build wheels
+name: Build Python Wheels
 
 on:
   push:
     tags:
-      - '[0-9].*'
+      - '\d+\.\d+\.[0-9a-z]+'
+
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for running workflow'
+        required: true
 
 jobs:
-  do_release:
-    name: Create release and build manylinux wheels
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Check out project
-      uses: actions/checkout@v2
-    
-    - name: Get tag
-      id: get_tag
-      # strip 'refs/tags/' from ref, store in variable called VERSION
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.get_tag.outputs.VERSION }} # VERSION from get_tag step above
-        release_name: v${{ steps.get_tag.outputs.VERSION }}
-        draft: false
-        prerelease: true
-
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install wheel setuptools_scm[toml]'>=3.4'
-        python setup.py download
-
-    - name: Build manylinux Python wheels
-      id: build_wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
-      with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
-        build-requirements: 'meson ninja'
-        system-packages: 'zlib-devel'
-
-    - name: Attach wheel and sdist assets to release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        mkdir -p dist
-        for audited in ./wheelhouse/*-manylinux*.whl; do
-            cp $audited dist
-        done
-        set -x
-        assets=()
-        for asset in ./dist/*; do
-          assets+=("-a" "$asset")
-        done
-        hub release edit "${assets[@]}" -m "${{ steps.get_tag.outputs.VERSION }}" "${{ steps.get_tag.outputs.VERSION }}"
-
-  do_mac_wheels:
-    needs: [do_release]
-    name: Build Mac wheels
-    runs-on: macos-latest
+  build_wheels:
+    name: Build Py3 Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
-    - name: Check out project
+
+    - name: Log reason (manual run only)
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        echo "Reason for triggering: ${{ github.event.inputs.reason }}"
+
+    - name: Check out
       uses: actions/checkout@v2
-    
-    - name: Get tag
-      id: get_tag
-      # strip 'refs/tags/' from ref, store in variable called VERSION
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Install dependencies, build wheels, and attach to release
+    - name: Install Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Build wheel
+      uses: pypa/cibuildwheel@v2.3.0
+      with:
+        output-dir: dist
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
+        CIBW_ARCHS_MACOS: x86_64 universal2
+        CIBW_ARCHS_LINUX: x86_64
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_SKIP: "*musllinux*"
+        CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel"
+
+    - name: Build sdist (Ubuntu only)
+      if: matrix.os == 'ubuntu-latest'
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install wheel
-        python setup.py download
-        pip wheel . -w dist
-        for asset in ./dist/*.whl; do
-            assets+=("-a" "$asset")
-        done
-        hub release edit "${assets[@]}" -m "${{ steps.get_tag.outputs.VERSION }}" "${{ steps.get_tag.outputs.VERSION }}"
-
-  do_pypi_publish:
-    needs: [do_release, do_mac_wheels]  # wait for the other jobs to complete
-    runs-on: ubuntu-latest  # pypa/gh-action-pypi-publish only runs on Linux...
-    
-    steps:
-    - name: Check out project
-      uses: actions/checkout@v2
-    
-    - name: Get tag
-      id: get_tag
-      # strip 'refs/tags/' from ref, store in variable called VERSION
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-
-    - name: Build Python source tarball
-      # do this here, because we can't use the GitHub .tar.gz (no PKG-INFO)
-      # should go into 'dist' folder to be picked up when publishing to PyPI
-      run: |
-        pip install wheel setuptools_scm[toml]'>=3.4'
         python setup.py sdist
 
-    - name: Download .whl assets from release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheelstorage
+        path: ./dist/*
+        if-no-files-found: error
+        retention-days: 30
+
+  publish_release:
+    name: Publish Release
+    needs: build_wheels
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Get date & flat tag
+      id: date_tag
       run: |
-        hub release download "${{ steps.get_tag.outputs.VERSION }}"
-        mkdir -p dist
-        cp *.whl dist # move .whl files to dist for publishing
-    
-    - name: Publish wheels to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+        export DATE=$(TZ=US/Pacific date +'%Y-%m-%d')
+        echo $DATE
+        export FLAT_TAG=$(echo ${GITHUB_REF##*/} | sed 's/\.//g')
+        echo $FLAT_TAG
+        echo ::set-output name=TODAY::$DATE
+        echo ::set-output name=VERSION::$FLAT_TAG
+      shell: bash
+
+    - name: Download release assets
+      uses: actions/download-artifact@v2
+      with:
+        name: wheelstorage
+        path: dist
+
+    - name: Publish dist(s) to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        body: '{{ steps.date_tag.outputs.VERSION }}-released-${{ steps.date_tag.outputs.TODAY }}'
+        prerelease: true
+        files: ./dist/*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # pyots (PYthon OT Sanitizer)
+
+[![Run Tests](https://github.com/adobe-type-tools/pyots/actions/workflows/run_tests.yml/badge.svg)](https://github.com/adobe-type-tools/pyots/actions/workflows/run_tests.yml) [![Build Python Wheels](https://github.com/adobe-type-tools/pyots/actions/workflows/release.yml/badge.svg)](https://github.com/adobe-type-tools/pyots/actions/workflows/release.yml)
+
+![PyPI](https://img.shields.io/pypi/v/pyots) [![PyPI](https://img.shields.io/pypi/pyversions/pyots)](https://pypi.org/project/pyots/)
+
+![macOS](https://img.shields.io/badge/-macOS-lightgrey) ![ubuntu](https://img.shields.io/badge/-ubuntu-lightgrey)
+
 Python wrapper for [OpenType Sanitizer](https://github.com/khaledhosny/ots), also known as just "OTS". It is similar to and partially based on [ots-python](https://github.com/googlefonts/ots-python), but builds OTS as a Python C Extension (instead of as an executable and calling through `subprocess` as ots-python does).
 
 **NOTE:** Although this package is similar to **ots-python**, it is _not_ a drop-in replacement for it, as the Python API is different.
 
 ## Requirements
-The project builds `pip`-installable wheels for Python 3.6, 3.7, 3.8, or 3.9 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
+The project builds `pip`-installable wheels for Python 3.7, 3.8, 3.9 or 3.10 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
 
 ## Installation with `pip`
 If you just want to _use_ `pyots`, you can simply run `pip install pyots` (in one of the supported platforms/Python versions) which will install pre-built, compiled, ready-to-use Python wheels. Then you can skip down to the [Use](#Use) section.
@@ -14,6 +21,7 @@ If you'd like to tinker with the `pyots` code, you will want to get your local s
  - clone this repo
  - run `python setup.py download` to download the OTS source (which is _not included_ in this project). You can modify the `version` value in [`setup.cfg`](./setup.cfg) under `[download]` to specify a different version of OTS. You'll also need to change the `sha256` hash value that corresponds to the OTS tar.xz package. Note that this scheme has some limitations: OTS sources older than 8.1.3 might not build correctly since they used different build systems. Also, versions newer than the one specified in this repo might require adjustments in order to build correctly. What can we say, we're dependent on `ots`...
  - to build and install `pyots` after downloading OTS, you can run `python setup.py install` or `pip install .`
+ - while iterating changes, you will want to delete the temporary `build` and `src/ots/build` folders.
 
 ## Testing
 There is a test suite defined for exercising the Python extension. It makes use (and assumes the presence of) the downloaded OTS library source's test font data in `src/ots` so ensure you have run `python setup.py download` and have the `ots` folder under `src`. Invoke the tests with `python -m pytest tests` *OR* `pytest tests` (make sure you specify `tests` folder, otherwise `pytest` will discover and attempt to execute other Python tests within the `ots` tree, which will probably fail)
@@ -25,25 +33,23 @@ import pyots
 result = pyots.sanitize('/path/to/font/file.ttf')
 ```
 
-`result` is an `OTSResult` ([`namedtuple`](https://docs.python.org/3/library/collections.html#collections.namedtuple)/lightweight object) with 3 attributes:
+`result` is an `OTSResult` object with 3 attributes:
  - `sanitized` Boolean indicating whether the file was successfully sanitized
  - `modified` Boolean indicating whether the file was modified* during sanitization
  - `messages` Tuple of message strings generated during sanitization (may be empty)
 
-* **Note:** currently the back-end OTS code _always_ modifies fonts that are successfully sanitized. Thus `modified` will be True for all cases where `sanitized` is True. Usually the modification is only to the modification date and related checksums. Thus, it might be possible to devise a better detection of modification, i.e. ignoring `head.modified` and other inconsequential modifications, but that was out-of-scope for this work.
+* **Note:** currently the back-end OTS code can modify fonts that are successfully sanitized, even when no changes are performed. Thus `modified` can sometimes be True when `sanitized` is True. Usually the modification is only to the modification date and related checksums. Thus, it might be possible to devise a better detection of modification, i.e. ignoring `head.modified` and other inconsequential modifications, but that was out-of-scope for this work.
 
 ### Example: sanitizing a folder of font files
 ```python
 # sanitize a folder of fonts. Print messages for any that were not successfully sanitized.
 import pyots
-import os
+from pathlib import Path
 
-foldername = 'path/to/folder'
-for filename in os.listdir(foldername):
-    filepath = os.path.join(foldername, filename)
-    result = pyots.sanitize(filepath)
+for filename in Path("src/tests/fonts/good").rglob("*"):
+    result = pyots.sanitize(filename.absolute())
     if not result.sanitized:
-      print('{}:\n{}'.format(filepath, "\n".join([m for m in result.messages])))
+        print('{}:\n{}'.format(filename, "\n".join([m for m in result.messages])))
 ```
 
 ### Options for `sanitize()`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [download]
 ; OpenType Sanitizer version that is downloaded from setup.py
-version = 8.1.4
+version = 8.2.0
 ; expected SHA-256 of the downloaded tarball. E.g. you can calculate it with:
 ; $ shasum -a 256 ots-X.X.X.tar.xz
-sha256 = f21b927b03248e392e416c765eea4940c21a4e82f09045bc893b141eb57f1e29
+sha256 = e56f173008996a6292756a6a43186a00e638ed48dd9334df4d9aa20981b442c0

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ class Download(Command):
                 )
                 # remove unused ('executable('ots-sanitize' and all after)
                 meson = re.sub(
-                    r"executable\('ots-sanitize'(.+)",
+                    r"ots_sanitize = executable\('ots-sanitize',(.+)",
                     '',
                     meson,
                     flags=re.MULTILINE | re.DOTALL,


### PR DESCRIPTION
- Sync with [upstream OTS 8.2.0 release](https://github.com/khaledhosny/ots/releases/tag/v8.2.0)
- [ci] drop Python 3.6, add Python 3.10
- [ci] switch to CIBW to build wheels (still macOS & Ubuntu only)
- [docs] update README.md with current info
