### PR TITLE
Updates for ots 8.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ Python wrapper for [OpenType Sanitizer](https://github.com/khaledhosny/ots), als
 The project builds `pip`-installable wheels for Python 3.7, 3.8, 3.9 or 3.10 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
 
 ## Installation with `pip`
-If you just want to _use_ `pyots`, you can simply run `pip install pyots` (in one of the supported platforms/Python versions) which will install pre-built, compiled, ready-to-use Python wheels. Then you can skip down to the [Use](#Use) section.
+If you just want to _use_ `pyots`, you can simply run `python -m pip install -U pyots` (in one of the supported platforms/Python versions) which will install pre-built, compiled, ready-to-use Python wheels. Then you can skip down to the [Use](#Use) section.
 
 ## Installation/setup for developing `pyots`
 If you'd like to tinker with the `pyots` code, you will want to get your local setup ready:
  - clone this repo
  - run `python setup.py download` to download the OTS source (which is _not included_ in this project). You can modify the `version` value in [`setup.cfg`](./setup.cfg) under `[download]` to specify a different version of OTS. You'll also need to change the `sha256` hash value that corresponds to the OTS tar.xz package. Note that this scheme has some limitations: OTS sources older than 8.1.3 might not build correctly since they used different build systems. Also, versions newer than the one specified in this repo might require adjustments in order to build correctly. What can we say, we're dependent on `ots`...
- - to build and install `pyots` after downloading OTS, you can run `python setup.py install` or `pip install .`
+ - to build and install `pyots` after downloading OTS, you can run `python setup.py install` or `python -m pip install .`
  - while iterating changes, you will want to delete the temporary `build` and `src/ots/build` folders.
 
 ## Testing
-There is a test suite defined for exercising the Python extension. It makes use (and assumes the presence of) the downloaded OTS library source's test font data in `src/ots` so ensure you have run `python setup.py download` and have the `ots` folder under `src`. Invoke the tests with `python -m pytest tests` *OR* `pytest tests` (make sure you specify `tests` folder, otherwise `pytest` will discover and attempt to execute other Python tests within the `ots` tree, which will probably fail)
+There is a test suite defined for exercising the Python extension. It makes use (and assumes the presence of) the downloaded OTS library source's test font data in `src/ots` so ensure you have run `python setup.py download` and have the `ots` folder under `src`. Invoke the tests with `python -m pytest`.
+
+If you wish to run tests comparing results from `ots-python` against `pyots`, be sure to `python -m pip install opentype-sanitizer` first, otherwise that set of tests will be skipped.
 
 ## Use
 Simplest case:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "ninja", "meson"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=3.4", "ninja", "meson"]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [download]
 ; OpenType Sanitizer version that is downloaded from setup.py
-version = 8.2.1
+version = 8.2.2
 ; expected SHA-256 of the downloaded tarball. E.g. you can calculate it with:
 ; $ shasum -a 256 ots-X.X.X.tar.xz
-sha256 = c9948c8ae61c50937afc6a0da6fb1c351fb7ea1ab30f796679d165447667e89f
+sha256 = d0d60d4bfb8cc8841ac8f91d3e562e47fa831d3e5c9b3bd7c05120391cf1f36b

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ SRC_SUB_DIR = OTS_SRC_DIR / "subprojects"
 # to avoid changing it with every new ots release (although it seems like every
 # release of ots has something that causes this build to break anyway so it's
 # not really that urgent. We just have to adjust every release.
-BROTLI_TAG = "1.0.7"
-LZ4_TAG = "1.9.3"
-WOFF2_TAG = "a0d0ed7da27b708c0a4e96ad7a998bddc933c06e"
+BROTLI_TAG = "1.0.9"
+LZ4_TAG = "1.9.4"
+WOFF2_TAG = "1.0.2"
 
 
 def _get_extra_objects():


### PR DESCRIPTION
- bump setup.cfg info to point to ots 8.2.2
- update brotli, lz4 & woff2 tags
- add config for pytest to automatically use "tests" path
- minor updates & improvements to README.md