### PR TITLE
Updates for ots 9.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
     name: Publish Release
     needs: build_wheels
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required by 'action-gh-release'
 
     steps:
 
@@ -94,8 +96,6 @@ jobs:
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         body: '${{ steps.date_tag.outputs.VERSION }} released ${{ steps.date_tag.outputs.TODAY }} - [Upstream OTS v${{ steps.date_tag.outputs.VERSION }} Release Notes](https://github.com/khaledhosny/ots/releases/tag/v${{ steps.date_tag.outputs.VERSION }})'
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
-        CIBW_ARCHS_MACOS: x86_64 universal2
+        CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
+        CIBW_ARCHS_MACOS: x86_64 arm64
+        CIBW_ENVIRONMENT_MACOS: "CFLAGS='-arch arm64 -arch x86_64' CXXFLAGS='-arch arm64 -arch x86_64' LDFLAGS='-arch arm64 -arch x86_64'"
         CIBW_ARCHS_LINUX: x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "*musllinux*"
@@ -73,10 +74,10 @@ jobs:
       run: |
         export DATE=$(TZ=US/Pacific date +'%Y-%m-%d')
         echo $DATE
-        export FLAT_TAG=$(echo ${GITHUB_REF##*/} | sed 's/\.//g')
+        export FLAT_TAG=$(echo ${GITHUB_REF##*/})
         echo $FLAT_TAG
-        echo ::set-output name=TODAY::$DATE
-        echo ::set-output name=VERSION::$FLAT_TAG
+        echo "TODAY=$DATE" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$FLAT_TAG" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Download release assets
@@ -96,6 +97,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        body: '{{ steps.date_tag.outputs.VERSION }}-released-${{ steps.date_tag.outputs.TODAY }}'
+        body: '${{ steps.date_tag.outputs.VERSION }} released ${{ steps.date_tag.outputs.TODAY }} - [Upstream OTS v${{ steps.date_tag.outputs.VERSION }} Release Notes](https://github.com/khaledhosny/ots/releases/tag/v${{ steps.date_tag.outputs.VERSION }})'
         prerelease: true
         files: ./dist/*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python wrapper for [OpenType Sanitizer](https://github.com/khaledhosny/ots), als
 **NOTE:** Although this package is similar to **ots-python**, it is _not_ a drop-in replacement for it, as the Python API is different.
 
 ## Requirements
-The project builds `pip`-installable wheels for Python 3.7, 3.8, 3.9 or 3.10 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
+The project builds `pip`-installable wheels for Python 3.8, 3.9, 3.10 or 3.11 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
 
 ## Installation with `pip`
 If you just want to _use_ `pyots`, you can simply run `python -m pip install -U pyots` (in one of the supported platforms/Python versions) which will install pre-built, compiled, ready-to-use Python wheels. Then you can skip down to the [Use](#Use) section.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [download]
 ; OpenType Sanitizer version that is downloaded from setup.py
-version = 9.0.0
+version = 9.1.0
 ; expected SHA-256 of the downloaded tarball. E.g. you can calculate it with:
 ; $ shasum -a 256 ots-X.X.X.tar.xz
-sha256 = 5982233f167266c6fa4d89bdd3aaddfaf7aad2f19053bc63abf901847d4403fa
+sha256 = e52efca9b6af41121deb71d867c6440b2d89b4cf189a9004f62a3989514acc22

--- a/setup.py
+++ b/setup.py
@@ -265,7 +265,7 @@ custom_commands = {
 pyots_mod = Extension(
     name='_pyots',
     libraries=['z'],
-    extra_compile_args=['-fPIC', '-std=c++17'],
+    extra_compile_args=['-fPIC', '-std=c++11'],
     extra_objects=_get_extra_objects(),
     include_dirs=_get_include_dirs(),
     sources=_get_sources(),
@@ -279,10 +279,10 @@ classifiers = [
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Testing',
     'License :: OSI Approved :: BSD License',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: POSIX :: Linux',
 ]

--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ setup(
     name='pyots',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     url='https://github.com/adobe-type-tools/pyots',
     use_scm_version=True,
     setup_requires=['setuptools_scm'],

--- a/src/_pyots/bindings.cpp
+++ b/src/_pyots/bindings.cpp
@@ -19,11 +19,11 @@
 static PyObject* method_sanitize(PyObject* self, PyObject* args) {
   PyObject* pyInFilenameObj;
   PyObject* pyOutFilenameObj;
-  bool quiet;
+  int quiet = 0;
   int kwFontIndex = -1;
 
   /* parse the Python args */
-  if (!PyArg_ParseTuple(args, "O&O&pi",
+  if (!PyArg_ParseTuple(args, "O&O&ii",
                         PyUnicode_FSConverter, &pyInFilenameObj,
                         PyUnicode_FSConverter, &pyOutFilenameObj,
                         &quiet,

--- a/src/pyots/__init__.py
+++ b/src/pyots/__init__.py
@@ -32,7 +32,6 @@ def sanitize(input, output=None, quiet=False, font_index=-1) -> OTSResult:
         messages (string)   Messages generated during sanitzation (empty if
                             'quiet' was specified as True).
     """
-    # (san, mod, rmsg) = _pyots._sanitize(input, output or os.devnull, quiet, font_index)
     (san, mod, rmsg) = _pyots._sanitize(input, output or '', quiet, font_index)
 
     if rmsg is not None:

--- a/tests/test_ots_suite.py
+++ b/tests/test_ots_suite.py
@@ -49,7 +49,7 @@ def test_ots_bad():
             count += 1
             print("[bad] unexpected success on", f, "\n".join(r.messages))
 
-    assert not count, f"{count} file{'s were' if count != 1 else 'was'} sanitized when expected to be sanitized."  # noqa: E501
+    assert not count, f"{count} file{'s were' if count != 1 else 'was'} sanitized successfully when expected to fail."  # noqa: E501
 
 
 def test_ots_fuzzing():


### PR DESCRIPTION
[config] Use ots v9.1.0 & updated sha256
[setup] set ECA std (back) to c++11
[py] remove commented-out code
[tests] clarify wording in test assertion message
[cpp] use int instead of bool for "quiet" param (alignment issue on arm64 was causing segfault) 
[ci] drop Python 3.7, add Python 3.11 builds
[setup] project classifiers: drop Python 3.7, add Python 3.11 [README] drop Python3.7, add Python 3.11 (requirements section)
[ci] don't use set-output
[ci] use arm64 (not universal2), fix release notes string, add arch flags for CIBW
