### PR TITLE
Tweaks to release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,10 @@ jobs:
         path: dist
 
     - name: Publish dist(s) to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+      with:
+        attestations: true
+        verbose: true
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '\d+\.\d+\.[0-9a-z]+'
+      - '\d+\.\d+\.[0-9a-z]+\.post\d+'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- add tag pattern to enable ".postN" tags to trigger release workflow
- pin pypa/gh-action-pypi-publish version explicitly
- add verbose flag to help diagnose future failures better
