### PR TITLE
Build Windows wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
 
@@ -28,18 +28,20 @@ jobs:
         echo "Reason for triggering: ${{ github.event.inputs.reason }}"
 
     - name: Check out
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
     - name: Install Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.14'
 
-    - name: Set up msbuild (Windows only)
-      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+    - name: Set up MSVC environment (Windows only)
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       if: startsWith(matrix.os, 'windows')
+      with:
+        arch: amd64
 
     - name: Build wheel
       uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
@@ -53,6 +55,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_SKIP: "*musllinux*"
         CIBW_BEFORE_ALL_LINUX: "yum install -y libuuid-devel"
+        CIBW_ARCHS_WINDOWS: AMD64
 
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
@@ -60,7 +63,7 @@ jobs:
         python setup.py sdist
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: wheelstorage-${{ matrix.os }}
         path: ./dist/*
@@ -74,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     permissions:
       id-token: write
       contents: write  # Required by 'action-gh-release'
@@ -93,7 +96,7 @@ jobs:
       shell: bash
 
     - name: Download release assets for ${{ matrix.os }}
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: wheelstorage-${{ matrix.os }}
         path: dist
@@ -105,7 +108,7 @@ jobs:
         verbose: true
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         body: '${{ steps.date_tag.outputs.VERSION }} released ${{ steps.date_tag.outputs.TODAY }} - [Upstream OTS v${{ steps.date_tag.outputs.VERSION }} Release Notes](https://github.com/khaledhosny/ots/releases/tag/v${{ steps.date_tag.outputs.VERSION }})'
         prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,9 @@ jobs:
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
       run: |
+        # Python 3.12+ no longer bundles setuptools, so install the sdist
+        # build deps before invoking setup.py directly
+        python -m pip install "setuptools>=61.0" setuptools_scm
         python setup.py sdist
 
     - name: Upload build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,6 @@ jobs:
       with:
         output-dir: dist
       env:
-        # use the 'pip' build frontend: cibuildwheel v3 defaults to
-        # 'python -m build', which (run from the project root) imports our
-        # top-level build.py instead of the pypa/build package and fails
-        CIBW_BUILD_FRONTEND: pip
         CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_ENVIRONMENT_MACOS: "CFLAGS='-arch arm64 -arch x86_64' CXXFLAGS='-arch arm64 -arch x86_64' LDFLAGS='-arch arm64 -arch x86_64'"
@@ -65,10 +61,8 @@ jobs:
     - name: Build sdist (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        # Python 3.12+ no longer bundles setuptools, so install the sdist
-        # build deps before invoking setup.py directly
-        python -m pip install "setuptools>=61.0" setuptools_scm
-        python setup.py sdist
+        python -m pip install build
+        python -m build --sdist
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
       with:
         output-dir: dist
       env:
+        # use the 'pip' build frontend: cibuildwheel v3 defaults to
+        # 'python -m build', which (run from the project root) imports our
+        # top-level build.py instead of the pypa/build package and fails
+        CIBW_BUILD_FRONTEND: pip
         CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
         CIBW_ARCHS_MACOS: x86_64 arm64
         CIBW_ENVIRONMENT_MACOS: "CFLAGS='-arch arm64 -arch x86_64' CXXFLAGS='-arch arm64 -arch x86_64' LDFLAGS='-arch arm64 -arch x86_64'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,9 @@ jobs:
 
   publish_release:
     name: Publish Release
-    needs: 
+    needs:
       - build_wheels
+    if: startsWith(github.ref, 'refs/tags/')  # only publish on tag releases
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -106,6 +107,7 @@ jobs:
       with:
         attestations: true
         verbose: true
+        skip-existing: true  # don't fail if a filename was already uploaded
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     name: Build Py3 Wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build Py3 Wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,6 @@ jobs:
       with:
         python-version: '3.14'
 
-    - name: Set up MSVC environment (Windows only)
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      if: startsWith(matrix.os, 'windows')
-      with:
-        arch: amd64
-
     - name: Build wheel
       uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
       with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -74,11 +74,6 @@ jobs:
       with:
         fetch-depth: 0  # Fetch full history for setuptools_scm
 
-    - name: Set up MSVC environment
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      with:
-        arch: amd64
-
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
     - README*
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       reason:
@@ -14,11 +14,11 @@ on:
 
 jobs:
   build:
-
+    name: Build & test (Linux)
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0  # Fetch full history for setuptools_scm
 
@@ -28,7 +28,7 @@ jobs:
         echo "Reason for triggering: ${{ github.event.inputs.reason }}"
 
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.14
 
@@ -60,7 +60,44 @@ jobs:
     - name: Build and install
       run: |
         python -m pip install -v .
-    
+
+    - name: Test with pytest
+      run: |
+        pytest -v tests
+
+  build-windows:
+    name: Build & test (Windows)
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0  # Fetch full history for setuptools_scm
+
+    - name: Set up MSVC environment
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      with:
+        arch: amd64
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: 3.14
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install setuptools>=61.0
+        python -m pip install -r requirements.txt
+
+    - name: Download OTS source
+      run: |
+        python setup.py download --version=9.2.0 --sha256=1a1e50cd7ecea27c4ef04c5b1491c21e75555f35bf91e27103ede04ddd11e053
+
+    - name: Build and install
+      run: |
+        python -m pip install -v .
+
     - name: Test with pytest
       run: |
         pytest -v tests

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 ![PyPI](https://img.shields.io/pypi/v/pyots) [![PyPI](https://img.shields.io/pypi/pyversions/pyots)](https://pypi.org/project/pyots/)
 
-![macOS](https://img.shields.io/badge/-macOS-lightgrey) ![ubuntu](https://img.shields.io/badge/-ubuntu-lightgrey)
+![macOS](https://img.shields.io/badge/-macOS-lightgrey) ![ubuntu](https://img.shields.io/badge/-ubuntu-lightgrey) ![windows](https://img.shields.io/badge/-windows-lightgrey)
 
 Python wrapper for [OpenType Sanitizer](https://github.com/khaledhosny/ots), also known as just "OTS". It is similar to and partially based on [ots-python](https://github.com/googlefonts/ots-python), but builds OTS as a Python C Extension (instead of as an executable and calling through `subprocess` as ots-python does).
 
 **NOTE:** Although this package is similar to **ots-python**, it is _not_ a drop-in replacement for it, as the Python API is different.
 
 ## Requirements
-The project builds `pip`-installable wheels for Python 3.10, 3.11, 3.12, 3.13, or 3.14 under Mac or Linux. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
+The project builds `pip`-installable wheels for Python 3.10, 3.11, 3.12, 3.13, or 3.14 under Mac, Linux, or Windows. It is possible this project will build and run with other Pythons and other operating systems, but it has only been tested with the listed configurations.
 
 ## Installation with `pip`
 If you just want to _use_ `pyots`, you can simply run `python -m pip install -U pyots` (in one of the supported platforms/Python versions) which will install pre-built, compiled, ready-to-use Python wheels. Then you can skip down to the [Use](#Use) section.

--- a/build.py
+++ b/build.py
@@ -27,13 +27,20 @@ TOOLS = {
     "ninja": os.environ.get("NINJA_EXE", "ninja"),
 }
 
+# On Windows there is no system zlib, so force meson to build it from the
+# subproject fallback (on Linux/macOS the system zlib is used and linked via
+# the extension's libraries=["z"]).
+FALLBACK_LIBS = "libbrotlidec,liblz4"
+if sys.platform == "win32":
+    FALLBACK_LIBS += ",zlib"
+
 MESON_CMD = [
     TOOLS["meson"],
     "--backend=ninja",
     "--buildtype=release",
     "--strip",
     "--default-library=static",
-    "--force-fallback-for=libbrotlidec,liblz4",
+    f"--force-fallback-for={FALLBACK_LIBS}",
     str(BUILD_DIR),
     str(OTS_SRC_DIR),
 ]

--- a/build_ots.py
+++ b/build_ots.py
@@ -31,8 +31,16 @@ TOOLS = {
 # subproject fallback (on Linux/macOS the system zlib is used and linked via
 # the extension's libraries=["z"]).
 FALLBACK_LIBS = "libbrotlidec,liblz4"
+
+# On Windows force meson to activate the Visual Studio (MSVC) environment via
+# its built-in vswhere/vcvars detection. Without --vsenv, meson would pick up
+# the gcc/clang that GitHub's windows runners ship on PATH, producing static
+# libs with a different ABI than the MSVC-built extension. --vsenv makes meson
+# find cl.exe itself, so no external MSVC-setup action is needed.
+WIN_MESON_ARGS = []
 if sys.platform == "win32":
     FALLBACK_LIBS += ",zlib"
+    WIN_MESON_ARGS = ["--vsenv"]
 
 MESON_CMD = [
     TOOLS["meson"],
@@ -41,6 +49,7 @@ MESON_CMD = [
     "--strip",
     "--default-library=static",
     f"--force-fallback-for={FALLBACK_LIBS}",
+    *WIN_MESON_ARGS,
     str(BUILD_DIR),
     str(OTS_SRC_DIR),
 ]

--- a/build_ots.py
+++ b/build_ots.py
@@ -61,7 +61,7 @@ def check_tools():
 
 
 def configure(reconfigure=False):
-    print(f"build.py: Running {' '.join(MESON_CMD)}")
+    print(f"build_ots.py: Running {' '.join(MESON_CMD)}")
     if not (BUILD_DIR / "build.ninja").exists():
         subprocess.run(MESON_CMD, check=True, env=os.environ)
     elif reconfigure:
@@ -69,7 +69,7 @@ def configure(reconfigure=False):
 
 
 def make(*targets, clean=False):
-    print(f"build.py: Running {' '.join(NINJA_CMD)}")
+    print(f"build_ots.py: Running {' '.join(NINJA_CMD)}")
     targets = list(targets)
     if clean:
         subprocess.run(NINJA_CMD + ["-t", "clean"] + targets, check=True, env=os.environ)

--- a/build_ots.py
+++ b/build_ots.py
@@ -78,8 +78,19 @@ def configure(reconfigure=False):
 
 
 def make(*targets, clean=False):
-    print(f"build_ots.py: Running {' '.join(NINJA_CMD)}")
     targets = list(targets)
+    if sys.platform == "win32":
+        # Build through 'meson compile' rather than invoking ninja directly: it
+        # re-activates the MSVC environment (stored by --vsenv at configure
+        # time) so cl.exe is on PATH for the compile step. Bare ninja runs in a
+        # separate process that wouldn't inherit that environment.
+        build_cmd = [TOOLS["meson"], "compile", "-C", str(BUILD_DIR)]
+        print(f"build_ots.py: Running {' '.join(build_cmd)}")
+        if clean:
+            subprocess.run(build_cmd + ["--clean"], check=True, env=os.environ)
+        subprocess.run(build_cmd + targets, check=True, env=os.environ)
+        return
+    print(f"build_ots.py: Running {' '.join(NINJA_CMD)}")
     if clean:
         subprocess.run(NINJA_CMD + ["-t", "clean"] + targets, check=True, env=os.environ)
     subprocess.run(NINJA_CMD + targets, check=True, env=os.environ)

--- a/build_ots.py
+++ b/build_ots.py
@@ -54,7 +54,7 @@ MESON_CMD = [
     str(OTS_SRC_DIR),
 ]
 
-NINJA_CMD = [TOOLS["ninja"], "-C", str(BUILD_DIR)]
+MESON_COMPILE_CMD = [TOOLS["meson"], "compile", "-C", str(BUILD_DIR)]
 
 
 class ExecutableNotFound(FileNotFoundError):
@@ -78,22 +78,15 @@ def configure(reconfigure=False):
 
 
 def make(*targets, clean=False):
+    # Build through 'meson compile' rather than invoking ninja directly. On
+    # Windows this re-activates the MSVC environment (stored by --vsenv at
+    # configure time) so cl.exe is on PATH for the compile step; on other
+    # platforms it simply drives the ninja backend.
     targets = list(targets)
-    if sys.platform == "win32":
-        # Build through 'meson compile' rather than invoking ninja directly: it
-        # re-activates the MSVC environment (stored by --vsenv at configure
-        # time) so cl.exe is on PATH for the compile step. Bare ninja runs in a
-        # separate process that wouldn't inherit that environment.
-        build_cmd = [TOOLS["meson"], "compile", "-C", str(BUILD_DIR)]
-        print(f"build_ots.py: Running {' '.join(build_cmd)}")
-        if clean:
-            subprocess.run(build_cmd + ["--clean"], check=True, env=os.environ)
-        subprocess.run(build_cmd + targets, check=True, env=os.environ)
-        return
-    print(f"build_ots.py: Running {' '.join(NINJA_CMD)}")
+    print(f"build_ots.py: Running {' '.join(MESON_COMPILE_CMD)}")
     if clean:
-        subprocess.run(NINJA_CMD + ["-t", "clean"] + targets, check=True, env=os.environ)
-    subprocess.run(NINJA_CMD + targets, check=True, env=os.environ)
+        subprocess.run(MESON_COMPILE_CMD + ["--clean"], check=True, env=os.environ)
+    subprocess.run(MESON_COMPILE_CMD + targets, check=True, env=os.environ)
 
 
 def main(args=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
 ]
 requires-python = ">=3.10"
 dynamic = ["version"]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ PY = sys.executable
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 log = logging.getLogger("pyots.setup")
 
-# Define paths (previously imported from build.py)
+# Define paths (previously imported from build_ots.py)
 try:
     ROOT = Path(__file__).parent.resolve()
 except NameError:
@@ -80,7 +80,7 @@ def _get_extra_objects():
     xo.append(_find_static_lib(lz4_dir, "lz4"))
 
     # zlib -- on Windows there's no system zlib, so meson builds it from the
-    # subproject fallback (see build.py) and we link it statically here. On
+    # subproject fallback (see build_ots.py) and we link it statically here. On
     # Linux/macOS the system zlib is linked via libraries=["z"] instead.
     if IS_WINDOWS:
         zlib_dirs = sorted(BUILD_SUB_DIR.glob("zlib-*"))
@@ -145,14 +145,14 @@ def _get_sources():
 
 class BuildStaticLibs(Command):
     """
-    Custom command to run build.py script prior to building Extension
+    Custom command to run build_ots.py script prior to building Extension
     """
 
     description = "Build ots static libs from source with meson/ninja"
     user_options = []
 
     def run(self):
-        cmd = [PY, "build.py"]
+        cmd = [PY, "build_ots.py"]
         subprocess.check_call(cmd)
 
     def initialize_options(self):
@@ -177,7 +177,7 @@ class BuildExt(build_ext):
     Custom build_ext that resolves the static libs to link against at build
     time. This must be deferred until here (rather than when the Extension is
     constructed at module load) because the libs don't exist on disk until
-    build.py has compiled them.
+    build_ots.py has compiled them.
     """
 
     def run(self):
@@ -329,7 +329,7 @@ pyots_mod = Extension(
     name="_pyots",
     libraries=libraries,
     extra_compile_args=extra_compile_args,
-    # extra_objects is populated at build time by BuildExt, once build.py has
+    # extra_objects is populated at build time by BuildExt, once build_ots.py has
     # compiled the static libs
     include_dirs=_get_include_dirs(),
     sources=_get_sources(),

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import shutil
 from pathlib import Path
 from setuptools import setup, Extension, Command
 from setuptools.command import build_py
+from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
 import subprocess
 import sys
@@ -165,6 +166,20 @@ class BuildPy(build_py.build_py):
         build_py.build_py.run(self)
 
 
+class BuildExt(build_ext):
+    """
+    Custom build_ext that resolves the static libs to link against at build
+    time. This must be deferred until here (rather than when the Extension is
+    constructed at module load) because the libs don't exist on disk until
+    build.py has compiled them.
+    """
+
+    def run(self):
+        for ext in self.extensions:
+            ext.extra_objects = _get_extra_objects()
+        build_ext.run(self)
+
+
 class CustomEggInfo(egg_info):
     def run(self):
         # make sure the ots source is downloaded before creating sdist manifest
@@ -298,6 +313,7 @@ class Download(Command):
 
 custom_commands = {
     "build_py": BuildPy,
+    "build_ext": BuildExt,
     "build_static": BuildStaticLibs,
     "download": Download,
     "egg_info": CustomEggInfo,
@@ -315,7 +331,8 @@ pyots_mod = Extension(
     name="_pyots",
     libraries=libraries,
     extra_compile_args=extra_compile_args,
-    extra_objects=_get_extra_objects(),
+    # extra_objects is populated at build time by BuildExt, once build.py has
+    # compiled the static libs
     include_dirs=_get_include_dirs(),
     sources=_get_sources(),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-from distutils import log
 import io
+import logging
 import os
 import re
 import shutil
@@ -8,10 +8,16 @@ from setuptools import setup, Extension, Command
 from setuptools.command import build_py
 from setuptools.command.build_ext import build_ext
 from setuptools.command.egg_info import egg_info
+from setuptools.errors import SetupError
 import subprocess
 import sys
 
 PY = sys.executable
+
+# distutils was removed from the stdlib in Python 3.12 (PEP 632), so use the
+# stdlib logging module instead of distutils.log for informational output
+logging.basicConfig(format="%(message)s", level=logging.INFO)
+log = logging.getLogger("pyots.setup")
 
 # Define paths (previously imported from build.py)
 try:
@@ -206,14 +212,10 @@ class Download(Command):
 
     def finalize_options(self):
         if self.version is None:
-            from distutils.errors import DistutilsSetupError
-
-            raise DistutilsSetupError("must specify --version to download")
+            raise SetupError("must specify --version to download")
 
         if self.sha256 is None:
-            from distutils.errors import DistutilsSetupError
-
-            raise DistutilsSetupError("must specify --sha256 of downloaded file")
+            raise SetupError("must specify --sha256 of downloaded file")
 
         if self.download_dir is None:
             self.download_dir = "src"
@@ -253,9 +255,7 @@ class Download(Command):
                 # use hashlib to verify the SHA-256 hash
                 actual_sha256 = hashlib.sha256(f.getvalue()).hexdigest()
                 if actual_sha256 != self.sha256:
-                    from distutils.errors import DistutilsSetupError
-
-                    raise DistutilsSetupError(
+                    raise SetupError(
                         "invalid SHA-256 checksum:\nactual:   {}\nexpected: {}".format(
                             actual_sha256, self.sha256
                         )
@@ -267,9 +267,7 @@ class Download(Command):
                         filelist = tar.getmembers()
                         first = filelist[0]
                         if not (first.isdir() and first.name.startswith("ots")):  # noqa: E501
-                            from distutils.errors import DistutilsSetupError
-
-                            raise DistutilsSetupError(
+                            raise SetupError(
                                 "The downloaded archive is not recognized as a valid ots source tarball"
                             )
                         # strip the root 'ots-X.X.X' directory first

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,24 @@ LZ4_TAG = "1.9.4"
 WOFF2_TAG = "1.0.2"
 
 
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _find_static_lib(search_dir, base):
+    """
+    Locate a static lib produced by meson regardless of the toolchain's naming
+    convention: GCC/Clang produce 'lib<base>.a' while MSVC produces '<base>.lib'
+    (and meson may nest it in subdirectories). Returns the resolved Path.
+    """
+    candidates = [f"lib{base}.a", f"{base}.lib", f"lib{base}.lib", f"{base}.a"]
+    for name in candidates:
+        # search recursively so we don't depend on meson's exact output layout
+        matches = sorted(search_dir.rglob(name))
+        if matches:
+            return matches[0]
+    raise FileNotFoundError(f"could not find static lib for '{base}' under {search_dir} (tried {candidates})")
+
+
 def _get_extra_objects():
     """
     Create the list of 'extra_ojects' for building the extension. This is done
@@ -42,15 +60,34 @@ def _get_extra_objects():
     of the static libs generated.
     """
     # libots
-    xo = [BUILD_DIR / "libots.a"]
+    xo = [_find_static_lib(BUILD_DIR, "ots")]
 
     # brotli
     # NOTE: decoder needs to come before common!
-    xo.append(BUILD_SUB_DIR / f"brotli-{BROTLI_TAG}" / "libbrotli_decoder.a")
-    xo.append(BUILD_SUB_DIR / f"brotli-{BROTLI_TAG}" / "libbrotli_common.a")
+    brotli_dir = BUILD_SUB_DIR / f"brotli-{BROTLI_TAG}"
+    xo.append(_find_static_lib(brotli_dir, "brotli_decoder"))
+    xo.append(_find_static_lib(brotli_dir, "brotli_common"))
 
     # lz4
-    xo.append(BUILD_SUB_DIR / f"lz4-{LZ4_TAG}" / "contrib" / "meson" / "meson" / "lib" / "liblz4.a")  # noqa: E501
+    lz4_dir = BUILD_SUB_DIR / f"lz4-{LZ4_TAG}"
+    xo.append(_find_static_lib(lz4_dir, "lz4"))
+
+    # zlib -- on Windows there's no system zlib, so meson builds it from the
+    # subproject fallback (see build.py) and we link it statically here. On
+    # Linux/macOS the system zlib is linked via libraries=["z"] instead.
+    if IS_WINDOWS:
+        zlib_dirs = sorted(BUILD_SUB_DIR.glob("zlib-*"))
+        if not zlib_dirs:
+            raise FileNotFoundError(f"could not find zlib build dir under {BUILD_SUB_DIR}")
+        # the zlib subproject may name its lib 'z' or 'zlib'
+        for base in ("zlib", "z", "zlibstatic"):
+            try:
+                xo.append(_find_static_lib(zlib_dirs[-1], base))
+                break
+            except FileNotFoundError:
+                continue
+        else:
+            raise FileNotFoundError(f"could not find zlib static lib under {zlib_dirs[-1]}")
 
     # woff2 -- skipped for now, building as part of Extension
     # xo.append(BUILD_SUB_DIR / f"woff2-{WOFF2_TAG}" / "libwoff2_decoder.a")
@@ -266,10 +303,18 @@ custom_commands = {
     "egg_info": CustomEggInfo,
 }
 
+if IS_WINDOWS:
+    # MSVC: no -fPIC, no system zlib (it's linked statically via extra_objects)
+    extra_compile_args = ["/std:c++14"]
+    libraries = []
+else:
+    extra_compile_args = ["-fPIC", "-std=c++11"]
+    libraries = ["z"]
+
 pyots_mod = Extension(
     name="_pyots",
-    libraries=["z"],
-    extra_compile_args=["-fPIC", "-std=c++11"],
+    libraries=libraries,
+    extra_compile_args=extra_compile_args,
     extra_objects=_get_extra_objects(),
     include_dirs=_get_include_dirs(),
     sources=_get_sources(),

--- a/tests/test_compare_ots_python.py
+++ b/tests/test_compare_ots_python.py
@@ -15,7 +15,10 @@ import pyots
 try:
     import ots
 
-    have_ots = True
+    # the pyots wheel bundles a top-level 'ots' package (the OTS source subset),
+    # so a bare 'import ots' can succeed even when the opentype-sanitizer package
+    # isn't installed; check for its sanitize() to confirm it's the real thing.
+    have_ots = hasattr(ots, "sanitize")
 except ImportError:
     have_ots = False
 

--- a/tests/test_ots_suite.py
+++ b/tests/test_ots_suite.py
@@ -63,7 +63,7 @@ def test_ots_fuzzing():
 
         r = pyots.sanitize(f)
 
-        if str(f.relative_to(TEST_FONTS_DIR)) in EXPECT_FAIL:
+        if f.relative_to(TEST_FONTS_DIR).as_posix() in EXPECT_FAIL:
             if r.sanitized:
                 count += 1
                 print("[fuzzing] unexpected success on", f, "\n".join(r.messages))


### PR DESCRIPTION
## Build Windows wheels

Closes #46.

This PR makes `pyots` build and publish Windows (x64/AMD64) wheels alongside the existing macOS and Linux ones, for CPython 3.10–3.14.

`pyots` compiles a real C extension that statically links the OTS libraries, and the existing build was Unix-only. The bulk of the work was making that build toolchain-agnostic.

### Build system
- **Cross-platform `setup.py`**: resolve the meson-built static libs by globbing for either `lib<name>.a` (GCC/Clang) or `<name>.lib` (MSVC) instead of hardcoding Unix names, and select MSVC vs. GCC/Clang compile flags per platform. Resolution of `extra_objects` is deferred to `build_ext`, since the libs don't exist on disk until the meson build has run.
- **zlib on Windows**: there's no system zlib, so meson builds it from the subproject fallback and it's linked statically into the extension.
- **MSVC without a third-party action**: meson is configured with `--vsenv` and the build is driven through `meson compile`, so it locates and activates the Visual Studio environment itself.
- Renamed the top-level `build.py` → `build_ots.py` so it no longer shadows the PyPA `build` package; this lets the wheel build use cibuildwheel's default frontend and the sdist use an isolated `python -m build --sdist`.

### CI
- `release.yml`: build + publish Windows wheels; publishing is gated to tag pushes and uses `skip-existing`.
- `run_tests.yml`: added a Windows build-and-test job.
- Fixed two test issues that only surfaced on Windows (path-separator normalization, and a skip guard for the bundled `ots` package).

### Validation
All three platforms build green in both workflows, and the full publish path was verified end-to-end against PyPI with throwaway pre-release tags (`9.2.0bN`) so no `.postN` release version was consumed.

### Release
The next release will be tagged `9.2.0.post3`. It will include Windows wheels. It will also include CPython 3.13 and 3.14 wheels for the first time. CPython 3.9 wheels will not be included.