### PR TITLE
Update OTS to v9.3.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,8 +46,8 @@ jobs:
 
     - name: Download OTS source
       run: |
-        python setup.py download --version=9.2.0 --sha256=1a1e50cd7ecea27c4ef04c5b1491c21e75555f35bf91e27103ede04ddd11e053
-    
+        python setup.py download --version=9.3.0 --sha256=23814f8e90ee77379f54e86a012c09bba2d133940e5257546b29cf087a73beec
+
     - name: Lint with ruff
       run: ruff check .
 
@@ -87,7 +87,7 @@ jobs:
 
     - name: Download OTS source
       run: |
-        python setup.py download --version=9.2.0 --sha256=1a1e50cd7ecea27c4ef04c5b1491c21e75555f35bf91e27103ede04ddd11e053
+        python setup.py download --version=9.3.0 --sha256=23814f8e90ee77379f54e86a012c09bba2d133940e5257546b29cf087a73beec
 
     - name: Build and install
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [download]
 ; OpenType Sanitizer version that is downloaded from setup.py
-version = 9.2.0
+version = 9.3.0
 ; expected SHA-256 of the downloaded tarball. E.g. you can calculate it with:
 ; $ shasum -a 256 ots-X.X.X.tar.xz
-sha256 = 1a1e50cd7ecea27c4ef04c5b1491c21e75555f35bf91e27103ede04ddd11e053
+sha256 = 23814f8e90ee77379f54e86a012c09bba2d133940e5257546b29cf087a73beec

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ SRC_SUB_DIR = OTS_SRC_DIR / "subprojects"
 # release of ots has something that causes this build to break anyway so it's
 # not really that urgent. We just have to adjust every release.
 BROTLI_TAG = "1.1.0"
-LZ4_TAG = "1.9.4"
+LZ4_TAG = "1.10.0"
 WOFF2_TAG = "1.0.2"
 
 

--- a/tests/test_compare_ots_python.py
+++ b/tests/test_compare_ots_python.py
@@ -4,8 +4,11 @@
 (opentype-sanitizer/ots) is not installed.
 """
 
+import configparser
 import functools
 import timeit
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from pathlib import Path
 
 import pytest
@@ -26,6 +29,31 @@ ROOT = Path(__file__).parent.parent.resolve()
 TEST_FONTS_DIR = ROOT / "src" / "ots" / "tests" / "fonts"
 
 
+def _ots_versions_match():
+    """
+    The comparison tests assert byte-identical messages between pyots and
+    ots-python, which only holds when both wrap the same OTS version. pyots
+    targets the version pinned in setup.cfg, while ots-python's package version
+    is its bundled OTS version. Skip the comparison when they differ (e.g. when
+    pyots is ahead of the latest opentype-sanitizer release), since the messages
+    legitimately diverge on OTS behavior changes.
+    """
+    if not have_ots:
+        return False
+    cfg = configparser.ConfigParser()
+    cfg.read(ROOT / "setup.cfg")
+    target = cfg.get("download", "version", fallback=None)
+    try:
+        installed = pkg_version("opentype-sanitizer")
+    except PackageNotFoundError:
+        return False
+    return target is not None and target == installed
+
+
+versions_match = _ots_versions_match()
+SKIP_REASON = "ots-python not installed or its OTS version differs from pyots's target"
+
+
 def _get_ots_result(path):
     """
     Sanitize with ots-python and process the result.
@@ -42,7 +70,7 @@ def _get_pyots_result(path):
     return pyots.sanitize(path)
 
 
-@pytest.mark.skipif(not have_ots, reason="ots-python not installed")
+@pytest.mark.skipif(not versions_match, reason=SKIP_REASON)
 def test_compare_good():
     tld = TEST_FONTS_DIR / "good"
 
@@ -53,7 +81,7 @@ def test_compare_good():
         assert otsp_result.messages == pyots_result.messages, f"[good] mismatched messages for {f}"
 
 
-@pytest.mark.skipif(not have_ots, reason="ots-python not available")
+@pytest.mark.skipif(not versions_match, reason=SKIP_REASON)
 def test_compare_bad():
     tld = TEST_FONTS_DIR / "bad"
 
@@ -64,7 +92,7 @@ def test_compare_bad():
         assert otsp_result.messages == pyots_result.messages, f"[bad] mismatched messages for {f}"
 
 
-@pytest.mark.skipif(not have_ots, reason="ots-python not available")
+@pytest.mark.skipif(not versions_match, reason=SKIP_REASON)
 def test_compare_fuzzing():
     tld = TEST_FONTS_DIR / "fuzzing"
 


### PR DESCRIPTION
## Summary
Integrates [OpenType Sanitizer v9.3.0](https://github.com/khaledhosny/ots/releases/tag/v9.3.0), bumping the pinned OTS version from 9.2.0.

## Changes
- **`setup.cfg`** — pinned `version` `9.2.0` → `9.3.0` and the tarball `sha256`.
- **`.github/workflows/run_tests.yml`** — updated `--version`/`--sha256` in the Linux and Windows "Download OTS source" steps.
- **`setup.py`** — `LZ4_TAG` `1.9.4` → `1.10.0` to match OTS 9.3.0's updated lz4 meson wrap. `BROTLI_TAG` (1.1.0) and `WOFF2_TAG` (1.0.2) are unchanged — those subproject source dirs did not change (only their wrapdb patch levels did).
- **`tests/test_compare_ots_python.py`** — the optional ots-python comparison tests now skip when the installed `opentype-sanitizer` version differs from pyots's target OTS version. `opentype-sanitizer` is still 9.2.0 on PyPI, so its messages legitimately diverge from OTS 9.3.0 (e.g. the new non-italic hhea/vhea caret warning); the tests auto-re-enable once it ships 9.3.0.

## Verification
Local build (macOS, `pip install .`) succeeds and `pytest` passes: `5 passed, 3 skipped` (the 3 skips are the version-mismatched comparison tests). `ruff check` and `ruff format --check` are clean. The `meson.build` patch logic in `setup.py`'s `download` command applies unchanged against the v9.3.0 tree.
